### PR TITLE
Alias Vercel Analytics import

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
-import { Analytics } from "@vercel/analytics/react";
-import { Analytics } from "@vercel/analytics/react";
+import { Analytics as VercelAnalytics } from "@vercel/analytics/react";
 import { Major_Mono_Display, Space_Mono } from "next/font/google";
 import Link from "next/link";
 
@@ -70,7 +69,7 @@ export default function RootLayout({
             </Link>
           </div>
         </footer>
-        <Analytics />
+        <VercelAnalytics />
       </body>
     </html>
   );


### PR DESCRIPTION
The auto-instrumentation already injects an `Analytics` import, so this aliases our manual import to `VercelAnalytics` before rendering `<VercelAnalytics />`. Fixes the redeclaration build failure.